### PR TITLE
Add bash scripts to install and serve the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,8 @@
 {
   "name": "faforever-newshub",
   "version": "1.0.0",
+  "private": true,
   "scripts": {
-    "bundle-install": "cd src && bundle install",
-    "build": "cd src && bundle exec jekyll build && npm run workbox-generate",
-    "serve": "cd src && bundle exec jekyll serve",
     "workbox-wizard": "workbox wizard",
     "workbox-generate": "workbox generateSW config/workbox-config.js",
     "minify-html": "node scripts/minify-html.js",

--- a/src/_setup-install.sh
+++ b/src/_setup-install.sh
@@ -1,0 +1,9 @@
+# Retrieves the packages required for this project 
+#
+# See also: 
+# - https://bundler.io/
+# - https://bundler.io/v2.6/man/bundle-install.1.html
+
+bundle install
+
+read

--- a/src/_setup-serve.sh
+++ b/src/_setup-serve.sh
@@ -1,0 +1,10 @@
+# Serves the website locally 
+# 
+# See also: 
+# - https://bundler.io/
+# - https://bundler.io/v2.6/man/bundle-exec.1.html
+# - https://jekyllrb.com/docs/usage/
+
+bundle exec jekyll serve
+
+read


### PR DESCRIPTION
Through these scripts you can install all dependencies and serve the website. The use of scripts makes it easier for non-developers to work with the repository.

Related to and mentioned in the [setup guide](https://github.com/FAForever/website-news/wiki/Setup).