### PR TITLE
Add a reference to GitHub and a timestamp when it was updated last

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -1,29 +1,31 @@
-<header class="wrapper site-header">
-  {%- assign default_paths = site.pages | map: 'path' -%}
-  {%- assign page_paths = site.header_pages | default: default_paths -%}
-  {%- assign titles_size = site.pages | map: 'title' | join: '' | size -%}
-  <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
 
-  {%- if titles_size > 0 -%}
-    <nav class="site-nav">
-      <label for="nav-trigger">
-        <input type="checkbox" id="nav-trigger" class="nav-trigger">
-        <span class="menu-icon">
-          <svg viewBox="0 0 18 15" width="18px" height="15px">
-            <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
-          </svg>
+<header class="wrapper ">
+  <div class="site-header">
+    <a class="site-header-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+
+    <div class="site-header-github">
+
+      <a
+        class="site-header-github-link"
+        href="https://github.com/FAForever/website-news"
+        target="_blank"
+        title="Github">
+          <span class=" icon-github"></span>
+      </a>
+
+      {% assign date_format = site.date_format | default: '%b %-d, %Y' %}
+
+      <div class="site-header-github-meta">
+        <span class="site-header-github-meta-field">
+          Last update at {{ site.time | date: date_format  }}
         </span>
-      </label>
-
-      <div class="trigger">
-        {%- for path in page_paths -%}
-          {%- assign my_page = site.pages | where: 'path', path | first -%}
-          {%- if my_page.title -%}
-            <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
-          {%- endif -%}
-        {%- endfor -%}
+        {% if site.github.commit %}
+        <span class="site-header-github-meta-field">
+          {{ site.github.commit  }}
+        </span>
+        {% endif %}
       </div>
-    </nav>
-  {%- endif -%}
+    </div>
+  </div>
 </header>
 

--- a/src/_sass/_header.scss
+++ b/src/_sass/_header.scss
@@ -2,23 +2,22 @@
  * Site header
  */
 .site-header {
-  border-top: 5px solid $border-color-03;
-  border-bottom: 1px solid $border-color-01;
-  min-height: $spacing-unit * 1.865;
-  line-height: $base-line-height * $base-font-size * 2.25;
+  grid-column: breakout-start / breakout-end;
+
+  display:flex;
+  justify-content: space-between;
 
   // Positioning context for the mobile navigation icon
   position: relative;
+
+  padding: 1em;
 }
 
-.site-title {
+.site-header-title {
   @include relative-font-size(1.625);
   font-weight: 300;
-  letter-spacing: -1px;
   margin-bottom: 0;
   float: left;
-
-  grid-column: content-start / content-end;
 
   @include media-query($on-palm) {
     padding-right: 45px;
@@ -30,90 +29,28 @@
   }
 }
 
-.site-nav {
-  position: absolute;
-  top: 9px;
-  right: $spacing-unit * 0.5;
-  background-color: $background-color;
-  border: 1px solid $border-color-01;
-  border-radius: 5px;
-  text-align: right;
+.site-header-github {
+  display: flex;
+  gap: 1ch;
+}
 
-  .nav-trigger {
-    display: none;
-  }
+.site-header-github-link {
+  @include relative-font-size(1.625);
+}
 
-  .menu-icon {
-    float: right;
-    width: 36px;
-    height: 26px;
-    line-height: 0;
-    padding-top: 10px;
-    text-align: center;
-
-    > svg path {
-      fill: $border-color-03;
-    }
-  }
-
-  label[for="nav-trigger"] {
-    display: block;
-    float: right;
-    width: 36px;
-    height: 36px;
-    z-index: 2;
-    cursor: pointer;
-  }
-
-  input ~ .trigger {
-    clear: both;
-    display: none;
-  }
-
-  input:checked ~ .trigger {
-    display: block;
-    padding-bottom: 5px;
-  }
-
-  .page-link {
-    color: $text-color;
-    line-height: $base-line-height;
-    display: block;
-    padding: 5px 10px;
-    margin-left: 20px;
-
-    // Gaps between nav items, but not on the last one
-    &:not(:last-child) {
-      margin-right: 0;
-    }
-  }
+.site-header-github-meta {
+  display: none;
 
   @media screen and (min-width: $on-medium) {
-    position: static;
-    float: right;
-    border: none;
-    background-color: inherit;
+    display: flex;
 
-    label[for="nav-trigger"] {
-      display: none;
-    }
-
-    .menu-icon {
-      display: none;
-    }
-
-    input ~ .trigger {
-      display: block;
-    }
-
-    .page-link {
-      display: inline;
-      padding: 0;
-      margin-left: auto;
-
-      &:not(:last-child) {
-        margin-right: 20px;
-      }
-    }
+    flex-direction: column;
+    justify-content: center;
+  
+    gap: 2px;
   }
+}
+
+.site-header-github-meta-field {
+  @include relative-font-size(0.8);
 }


### PR DESCRIPTION
Updates the header to remove the unused navigation menu and replace it with a reference to GitHub and when it was last updated. We use the `time` field of the [site](https://jekyllrb.com/docs/variables/#site-variables) variable for that.