### PR TITLE
Removes the distinction between post types

### DIFF
--- a/src/_posts/2025/2025-01-05-fall-tourney-02.md
+++ b/src/_posts/2025/2025-01-05-fall-tourney-02.md
@@ -3,7 +3,6 @@ layout: post
 title: Fall tourney 2024
 date: 2025-01-05 12:00:00 +0100
 categories: tournament
-type: regular
 status: live
 priority: 600
 redirectURL: https://forum.faforever.com/category/1/announcements

--- a/src/_posts/2025/2025-01-12-summer-tourney.md
+++ b/src/_posts/2025/2025-01-12-summer-tourney.md
@@ -3,7 +3,6 @@ layout: post
 title: Summer tourney 2024
 date: 2025-01-12 12:00:00 +0100
 categories: tournament
-type: regular
 status: live
 priority: 600
 

--- a/src/_posts/2025/2025-01-19-spring-tourney.md
+++ b/src/_posts/2025/2025-01-19-spring-tourney.md
@@ -3,7 +3,6 @@ layout: post
 title: Spring tourney 2024
 date: 2025-01-19 12:00:00 +0100
 categories: tournament
-type: regular
 status: live
 priority: 600
 

--- a/src/_posts/2025/2025-01-20-ice-adapter-fix.md
+++ b/src/_posts/2025/2025-01-20-ice-adapter-fix.md
@@ -4,7 +4,6 @@ title: Fix for the ICE adapter is live
 date: 2025-01-20 12:00:00 +0100
 
 categories: development
-type: featured
 status: live
 priority: 1000
 

--- a/src/_posts/2025/2025-01-23-spring-tourney.md
+++ b/src/_posts/2025/2025-01-23-spring-tourney.md
@@ -3,7 +3,6 @@ layout: post
 title: Spring tourney 2024 - pt. 2
 date: 2025-01-23 12:00:00 +0100
 categories: tournament
-type: regular
 status: live
 priority: 600
 

--- a/src/_posts/2025/2025-02-22-build-order.md
+++ b/src/_posts/2025/2025-02-22-build-order.md
@@ -4,7 +4,6 @@ title: First 10 Minutes of Every Game Made Easy
 date: 2025-02-22 12:00:00 +0100
 
 categories: guide
-type: regular
 status: live
 priority: 700
 

--- a/src/_posts/2025/2025-03-01-seton-tourney.md
+++ b/src/_posts/2025/2025-03-01-seton-tourney.md
@@ -4,7 +4,6 @@ title: Seton's Clutch tourney 2024
 date: 2025-03-01 12:00:00 +0100
 
 categories: tournament
-type: regular
 status: live
 priority: 600
 

--- a/src/_posts/2025/2025-03-08-winter-tourney.md
+++ b/src/_posts/2025/2025-03-08-winter-tourney.md
@@ -4,7 +4,6 @@ title: Winter tourney 2024
 date: 2025-03-08 12:00:00 +0100
 
 categories: tournament
-type: regular
 status: live
 priority: 600
 

--- a/src/_posts/2025/2025-03-15-what-idea-is-that.md
+++ b/src/_posts/2025/2025-03-15-what-idea-is-that.md
@@ -4,7 +4,6 @@ title: What idea is that!
 date: 2024-03-15 12:32:04 +0100
 
 categories: community
-type: regular
 status: live
 priority: 500
 

--- a/src/index.html
+++ b/src/index.html
@@ -9,25 +9,18 @@ layout: base
 
 {% assign posts = site.posts | sort: 'priority' | reverse %}
 
-{% assign livePosts = site.posts | where: 'status', 'live' %}
-
-{% assign eventLivePosts = livePosts | where_exp: 'post', 'post.event' | slice: 0, 5 %}
-
-{% assign featuredLivePosts = livePosts | where: 'type', 'featured' %}
-
-{% assign regularLivePosts = livePosts | where: 'type', 'regular' %}
+{% assign eventPosts = posts | where_exp: 'post', 'post.event' | slice: 0, 5 %}
+{% assign featurePost = posts | first %}
+{% assign remainingPosts = posts | shift %}
 
 <section class="wrapper wrapper-body">
   <section class="top-container">
     <div class="post-featured-container">
-      {%- if featuredLivePosts.size > 0 -%}
-        {% assign featuredLivePost = featuredLivePosts | first %}
-        {% include post/featured.html post=featuredLivePost %}
-      {%- endif -%}
+      {% include post/featured.html post=featurePost %}
     </div>
     <div class="post-event-container ">
       <ul class="post-event-list post-card">
-        {%- for postEvent in eventLivePosts -%}
+        {%- for postEvent in eventPosts -%}
           <li class="post-event-item">
             {% include post/event.html post=postEvent %}
             {% include components/divider.html %}
@@ -43,9 +36,9 @@ layout: base
     </div>
   </section>
 
-  {%- if regularLivePosts.size > 0 -%}
+  {%- if remainingPosts.size > 0 -%}
     <ul class="post-small-item-list-container">
-      {%- for post in regularLivePosts -%}
+      {%- for post in remainingPosts -%}
         <li class="post-small-item-container post-card">
           {% include post/small.html post=post %}
         </li>


### PR DESCRIPTION
The distinction makes it needlessly complex to work with posts. Instead, just like the current news hub, the post with the highest priority that is not archived is considered to be the 'featured' post.